### PR TITLE
Add `mythic` rarity and no rarity option

### DIFF
--- a/src/main/java/net/tooltiprareness/config/TooltipRarenessConfig.java
+++ b/src/main/java/net/tooltiprareness/config/TooltipRarenessConfig.java
@@ -25,6 +25,8 @@ public class TooltipRarenessConfig implements ConfigData {
     public int legendary_frame_color = 0xFFFFAA00;
     @ConfigEntry.Category("advanced_settings")
     public int administrator_frame_color = 0xFF555555;
+    @ConfigEntry.Category("advanced_settings")
+    public int mythic_frame_color = 0xFF56EDF5;
 
     @ConfigEntry.Category("advanced_settings")
     public int common_second_frame_color = 0xFF2A2A2A;
@@ -38,6 +40,8 @@ public class TooltipRarenessConfig implements ConfigData {
     public int legendary_second_frame_color = 0xFF664200;
     @ConfigEntry.Category("advanced_settings")
     public int administrator_second_frame_color = 0xFF151515;
+    @ConfigEntry.Category("advanced_settings")
+    public int mythic_frame_color = 0xFF2ABCC7;
 
     @ConfigEntry.Category("advanced_settings")
     public boolean changeBackgroundColor = false;

--- a/src/main/java/net/tooltiprareness/mixin/ItemStackMixin.java
+++ b/src/main/java/net/tooltiprareness/mixin/ItemStackMixin.java
@@ -31,6 +31,8 @@ public class ItemStackMixin {
     private static final TagKey<Item> EPIC_ITEM = TagKey.of(Registry.ITEM_KEY, new Identifier("tooltiprareness", "epic_item"));
     private static final TagKey<Item> LEGENDARY_ITEM = TagKey.of(Registry.ITEM_KEY, new Identifier("tooltiprareness", "legendary_item"));
     private static final TagKey<Item> ADMIN_ITEM = TagKey.of(Registry.ITEM_KEY, new Identifier("tooltiprareness", "admin_item"));
+    private static final TagKey<Item> MYTHIC_ITEM = TagKey.of(Registry.ITEM_KEY, new Identifier("tooltiprareness", "mythic_item"));
+    private static final TagKey<Item> NONE_ITEM = TagKey.of(Registry.ITEM_KEY, new Identifier("tooltiprareness", "none_item"));
 
     @Inject(method = "getTooltip", at = @At(value = "TAIL"), locals = LocalCapture.CAPTURE_FAILSOFT)
     private void getTooltipMixin(@Nullable PlayerEntity player, TooltipContext context, CallbackInfoReturnable<List<Text>> info, List<Text> list) {
@@ -48,6 +50,10 @@ public class ItemStackMixin {
                 list.add(1, new TranslatableText("item.tooltiprareness.legendary_item.tooltip"));
             } else if (stack.isIn(ADMIN_ITEM)) {
                 list.add(1, new TranslatableText("item.tooltiprareness.admin_item.tooltip"));
+            } else if (stack.isIn(MYTHIC_ITEM)) {
+                list.add(1, new TranslatableText("item.tooltiprareness.mythic_item.tooltip"));
+            } else if (stack.isIn(NONE_ITEM)) {
+                list.add(0, new TranslatableText("item.tooltiprareness.none_item.tooltip"));
             } else {
                 list.add(1, new TranslatableText("item.tooltiprareness.common_item.tooltip"));
             }

--- a/src/main/java/net/tooltiprareness/mixin/ScreenMixin.java
+++ b/src/main/java/net/tooltiprareness/mixin/ScreenMixin.java
@@ -71,6 +71,8 @@ public class ScreenMixin {
                 return TooltipRareness.CONFIG.legendary_frame_color;
             else if (getTooltipFromItem(itemStack).get(1).getString().equals(new TranslatableText("item.tooltiprareness.admin_item.tooltip").getString()))
                 return TooltipRareness.CONFIG.administrator_frame_color;
+            else if (getTooltipFromItem(itemStack).get(1).getString().equals(new TranslatableText("item.tooltiprareness.mythic_item.tooltip").getString()))
+                return TooltipRareness.CONFIG.mythic_frame_color;
         }
 
         return original;
@@ -91,6 +93,8 @@ public class ScreenMixin {
                 return TooltipRareness.CONFIG.legendary_second_frame_color;
             else if (getTooltipFromItem(itemStack).get(1).getString().equals(new TranslatableText("item.tooltiprareness.admin_item.tooltip").getString()))
                 return TooltipRareness.CONFIG.administrator_second_frame_color;
+            else if (getTooltipFromItem(itemStack).get(1).getString().equals(new TranslatableText("item.tooltiprareness.mythic_item.tooltip").getString()))
+                return TooltipRareness.CONFIG.mythic_second_frame_color;
         return original;
     }
 

--- a/src/main/resources/assets/tooltiprareness/lang/en_us.json
+++ b/src/main/resources/assets/tooltiprareness/lang/en_us.json
@@ -20,6 +20,7 @@
     "text.autoconfig.tooltiprareness.option.epic_frame_color": "Epic Frame Color",
     "text.autoconfig.tooltiprareness.option.legendary_frame_color": "Legendary Frame Color",
     "text.autoconfig.tooltiprareness.option.administrator_frame_color": "Administrator Frame Color",
+    "text.autoconfig.tooltiprareness.option.mythic_frame_color": "Mythic Frame Color",
 
     "text.autoconfig.tooltiprareness.option.common_second_frame_color": "Common Second Frame Color",
     "text.autoconfig.tooltiprareness.option.uncommon_second_frame_color": "Uncommon Second Frame Color",
@@ -27,6 +28,7 @@
     "text.autoconfig.tooltiprareness.option.epic_second_frame_color": "Epic Second Frame Color",
     "text.autoconfig.tooltiprareness.option.legendary_second_frame_color": "Legendary Second Frame Color",
     "text.autoconfig.tooltiprareness.option.administrator_second_frame_color": "Administrator Second Frame Color",
+    "text.autoconfig.tooltiprareness.option.mythic_second_frame_color": "Mythic Second Frame Color",
 
     "text.autoconfig.tooltiprareness.option.changeBackgroundColor": "Change Background Color",
     "text.autoconfig.tooltiprareness.option.backgroundColor": "Background Color"

--- a/src/main/resources/assets/tooltiprareness/lang/en_us.json
+++ b/src/main/resources/assets/tooltiprareness/lang/en_us.json
@@ -4,7 +4,9 @@
     "item.tooltiprareness.rare_item.tooltip": "§cRare",
     "item.tooltiprareness.epic_item.tooltip": "§5Epic",
     "item.tooltiprareness.legendary_item.tooltip": "§6Legendary",
+    "item.tooltiprareness.mythic_item.tooltip": "§bMythic",
     "item.tooltiprareness.admin_item.tooltip": "§8Administrator",
+    "item.tooltiprareness.none_item.tooltip": "",
 
     "text.autoconfig.tooltiprareness.title": "TooltipRareness Config",
     "text.autoconfig.tooltiprareness.category.default": "Default Settings",

--- a/src/main/resources/data/tooltiprareness/tags/items/mythic_item.json
+++ b/src/main/resources/data/tooltiprareness/tags/items/mythic_item.json
@@ -1,0 +1,5 @@
+{
+    "replace": false,
+    "values": [
+    ]
+}

--- a/src/main/resources/data/tooltiprareness/tags/items/none_item.json
+++ b/src/main/resources/data/tooltiprareness/tags/items/none_item.json
@@ -1,0 +1,5 @@
+{
+    "replace": false,
+    "values": [
+    ]
+}


### PR DESCRIPTION
Added in a `mythic` rarity in case a datapack allows for getting spawn eggs/a mod adds in higher tier gear than what is obtainable in vanilla, also added in no rarity in case you don't want an item to have a rarity/a mod already has built in rarities for its items.