### PR TITLE
fix npe

### DIFF
--- a/src/main/java/net/tooltiprareness/mixin/ScreenMixin.java
+++ b/src/main/java/net/tooltiprareness/mixin/ScreenMixin.java
@@ -44,7 +44,7 @@ public class ScreenMixin {
 
     @Inject(method = "getTooltipFromItem", at = @At("HEAD"))
     private void getTooltipFromItem(ItemStack stack, CallbackInfoReturnable<List<Text>> info) {
-        if (stack.equals(null))
+        if (stack == null)
             this.tooltipItemStack = null;
         else
             this.tooltipItemStack = stack;


### PR DESCRIPTION
calling `.equals()` on a `null` object will raise an npe, even if the object is being compared to `null`